### PR TITLE
[3] Updated addition feature for break line delimiters

### DIFF
--- a/src/StringCalculator.php
+++ b/src/StringCalculator.php
@@ -4,5 +4,15 @@ namespace Deg540\StringCalculatorPHP;
 
 class StringCalculator
 {
-    // TODO: String Calculator Kata
+    public function add(string $numbers): int
+    {
+        if ($numbers === "") {
+            return 0;
+        }
+        $add = 0;
+        foreach (explode(",", $numbers) as &$number) {
+            $add += intval($number);
+        }
+        return $add;
+    }
 }

--- a/src/StringCalculator.php
+++ b/src/StringCalculator.php
@@ -10,8 +10,10 @@ class StringCalculator
             return 0;
         }
         $add = 0;
-        foreach (explode(",", $numbers) as &$number) {
+        $number = strtok($numbers, ",\n");
+        while ($number !== false) {
             $add += intval($number);
+            $number = strtok(",\n");
         }
         return $add;
     }

--- a/tests/StringCalculatorTest.php
+++ b/tests/StringCalculatorTest.php
@@ -50,4 +50,14 @@ final class StringCalculatorTest extends TestCase
         $this->assertEquals(10, $stringCalculator->add("1,2,3,4"));
         $this->assertEquals(15, $stringCalculator->add("1,2,3,4,5"));
     }
+
+    /**
+     * @test
+     **/
+    public function returnAddResultIfNumbersStringWithBreakLinesIsPassed()
+    {
+        $stringCalculator = new StringCalculator();
+
+        $this->assertEquals(6, $stringCalculator->add("1\n2,3"));
+    }
 }

--- a/tests/StringCalculatorTest.php
+++ b/tests/StringCalculatorTest.php
@@ -9,5 +9,33 @@ use PHPUnit\Framework\TestCase;
 
 final class StringCalculatorTest extends TestCase
 {
-    // TODO: String Calculator Kata Tests
+    /**
+     * @test
+     **/
+    public function returnZeroIfVoidStringIsPassed()
+    {
+        $stringCalculator = new StringCalculator();
+
+        $this->assertEquals(0, $stringCalculator->add(""));
+    }
+
+    /**
+     * @test
+     **/
+    public function returnNumberIfOneNumberStringIsPassed()
+    {
+        $stringCalculator = new StringCalculator();
+
+        $this->assertEquals(1, $stringCalculator->add("1"));
+    }
+
+    /**
+     * @test
+     **/
+    public function returnAddResultIfTwoNumbersStringIsPassed()
+    {
+        $stringCalculator = new StringCalculator();
+
+        $this->assertEquals(3, $stringCalculator->add("1,2"));
+    }
 }

--- a/tests/StringCalculatorTest.php
+++ b/tests/StringCalculatorTest.php
@@ -38,4 +38,16 @@ final class StringCalculatorTest extends TestCase
 
         $this->assertEquals(3, $stringCalculator->add("1,2"));
     }
+
+    /**
+     * @test
+     **/
+    public function returnAddResultIfMultipleNumbersStringIsPassed()
+    {
+        $stringCalculator = new StringCalculator();
+
+        $this->assertEquals(6, $stringCalculator->add("1,2,3"));
+        $this->assertEquals(10, $stringCalculator->add("1,2,3,4"));
+        $this->assertEquals(15, $stringCalculator->add("1,2,3,4,5"));
+    }
 }


### PR DESCRIPTION
# Problem:

3. Permite al método "add" manejar saltos de línea entre números en lugar de usar comas.
    * La siguiente entrada es correcta: "1\n2,3" (el resultado será 6)
    * La siguiente entrada NO es correcta: "1,\n" (no hace falta que la pruebes, es simplemente para clarificar)

# Solution:

One test has been added following TDD for the case of the problem:
  * Return the add result if a numbers string with break line delimiters is passed as argument.

The "add" function has been updated by replacing the use of "explode" with "strtok" in order to have multiple delimiters (commas and line breaks).